### PR TITLE
Merge without append

### DIFF
--- a/acre/core.py
+++ b/acre/core.py
@@ -262,8 +262,8 @@ def merge(env, current_env, missing=None):
     result = current_env.copy()
     for key, value in env.items():
         if not isinstance(value, str):
-            result[key] = str(value)
-            continue
+            value = str(value)
+
         value = lib.partial_format(value, data=current_env, missing=missing)
 
         result[key] = str(value)

--- a/acre/core.py
+++ b/acre/core.py
@@ -240,7 +240,7 @@ def get_tools(tools, platform_name=None):
     return environment
 
 
-def merge(env, current_env):
+def merge(env, current_env, missing=None):
     """Merge the tools environment with the 'current_env'.
 
     This finalizes the join with a current environment by formatting the
@@ -252,6 +252,8 @@ def merge(env, current_env):
         env (dict): The dynamic environment
         current_env (dict): The "current environment" to merge the dynamic
             environment into.
+        missing (str): Argument passed to 'partial_format' during merging.
+            `None` should keep missing keys unchanged.
 
     Returns:
         dict: The resulting environment after the merge.
@@ -262,7 +264,7 @@ def merge(env, current_env):
         if not isinstance(value, str):
             result[key] = str(value)
             continue
-        value = lib.partial_format(value, data=current_env, missing="")
+        value = lib.partial_format(value, data=current_env, missing=missing)
 
         value = str(value)
         bckwrd = re.compile(r'^\\').search(value)

--- a/acre/core.py
+++ b/acre/core.py
@@ -266,17 +266,6 @@ def merge(env, current_env, missing=None):
             continue
         value = lib.partial_format(value, data=current_env, missing=missing)
 
-        value = str(value)
-        bckwrd = re.compile(r'^\\').search(value)
-        url = re.compile(r'://').search(value)
-
-        if url:
-            result[key] = value
-            continue
-
-        if not bckwrd:
-            value = os.path.normpath(value)
-
-        lib.append_path(result, key, os.path.normpath(value))
+        result[key] = str(value)
 
     return result

--- a/acre/lib.py
+++ b/acre/lib.py
@@ -81,11 +81,12 @@ def topological_sort(dependency_pairs):
     return Results(ordered, cyclic)
 
 
-def append_path(self, key, path):
-    """Append *path* to *key* in *self*."""
+def append_path(env, key, path):
+    """Append *path* to *key* in *env*."""
 
-    try:
-        if path not in self[key].split(os.pathsep):
-            self[key] = os.pathsep.join([self[key], str(path)])
-    except KeyError:
-        self[key] = str(path)
+    orig_value = env.get(key)
+    if not orig_value:
+        env[key] = str(path)
+
+    elif path not in orig_value.split(os.pathsep):
+        env[key] = os.pathsep.join([orig_value, str(path)])


### PR DESCRIPTION
## Issue
Merge function automatically appends values from one to another which is not wanted in most of cases. And it is not possible to pass "missing key" value for partial forrmating which is limmiting.

## Changes
- merge does not automatically append but only do formatting
- it is possible to pass `missing` value for `partial_format` function

## Note
This way is "prediction of paths" in `merge` function is limited to zero and environments are just values with possible formatting keys inside defining that it extend value or without formatting keys which overrides value. There is no duplicate value validation or normalization of paths.
