### PR TITLE
Ignore values with invalid curly braces or other invalid characters in the formatting

### DIFF
--- a/acre/lib.py
+++ b/acre/lib.py
@@ -53,7 +53,7 @@ def partial_format(s, data, missing="{{{key}}}"):
         for m in matches:
             try:
                 f = re.sub(m, m.format(**data), f)
-            except KeyError:
+            except (KeyError, ValueError):
                 continue
     return f
 


### PR DESCRIPTION
Ignore values that don't have correct braces to e.g. allow some linux BASH_FUNCTIONs to exist in environment as reported on OpenPype discord [here](https://discord.com/channels/517362899170230292/890894521817260052/1144227855631384716)